### PR TITLE
Specify that this package is an ES module

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@georgedoescode/spline",
   "version": "1.0.1",
   "description": "",
+  "type": "module",
   "main": "spline.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Importing this package to bundlers like Vite causes this error:
```
@georgedoescode/spline doesn't appear to be written in CJS, but also doesn't appear to be a valid ES module (i.e. it doesn't have "type": "module" or an .mjs extension for the entry point). Please contact the package author to fix.
```
The error is right, you are using
```js
export { spline }
```
which is ES module syntax. (If this was a CommonJS package, you'd be using `module.exports = { spline }`)

Adding `"type": "module"` to package.json fixes this issue